### PR TITLE
Fix vagrant command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ PRIVATE NETWORK. Use this to easily jump around in the file.
 
 1. Add this base box to Vagrant with:
    * ```vagrant box add trusty32-lamp
-   https://www.dropbox.com/sh/oy1av6uhod3yeto/PaA1XEbWux/trusty32-lamp.box```.
+   https://dl.dropboxusercontent.com/sh/oy1av6uhod3yeto/PaA1XEbWux/trusty32-lamp.box```.
    * Or optionally [verify your download](#verifying-basebox-integrity).
 1. Clone ```this repo``` to get the base Vagrantfile.
 1. Decide on a hostname and IP address for your VM.


### PR DESCRIPTION
In _Vagrant 1.4.3_ for Mac the `--name` flag was making this fail.
