### PR TITLE
Drush 8 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,11 @@ file to be loaded by Drush:
 ```php
 <?php
 $dir = getcwd();
-while (!in_array($dir, $options['alias-path'])) {
-  $options['alias-path'][] = $dir;
+while ($dir != '/') {
+  if (in_array('site-aliases', scandir($dir))) {
+    $options['alias-path'][] = $dir . '/site-aliases';
+    break;
+  }
   $dir = dirname($dir);
 }
 ```

--- a/site-aliases/aliases.drushrc.php
+++ b/site-aliases/aliases.drushrc.php
@@ -2,16 +2,19 @@
 
 /**
  * Need to include the following via ~/.drushrc.php. This walks up the tree
- * looking for alias files.
+ * looking for alias files in a site-aliases directory.
  */
 // $dir = getcwd();
-// while (!in_array($dir, $options['alias-path'])) {
-//   $options['alias-path'][] = $dir;
+// while ($dir != '/') {
+//   if (in_array('site-aliases', scandir($dir))) {
+//     $options['alias-path'][] = $dir . '/site-aliases';
+//     break;
+//   }
 //   $dir = dirname($dir);
 // }
 
 // Generates an alias for the current project from HOSTNAME in the Vagrantfile.
-$vagrant_directory = dirname(__FILE__);
+$vagrant_directory = dirname(dirname(__FILE__));
 $vagrantfile = $vagrant_directory . '/Vagrantfile';
 
 if (!file_exists($vagrantfile)) {
@@ -28,7 +31,7 @@ if (isset($matches[1])) {
     'uri' => $fqdn,
     'remote-host' => $fqdn,
     'remote-user' => 'vagrant',
-    'ssh-options' => '-i ~/.vagrant.d/insecure_private_key',
+    'ssh-options' => "-i " . $vagrant_directory . "/.vagrant/machines/default/virtualbox/private_key",
     'root' => '/var/www/docroot',
   );
 }

--- a/site-aliases/aliases.drushrc.php
+++ b/site-aliases/aliases.drushrc.php
@@ -25,9 +25,14 @@ $contents = file_get_contents($vagrantfile);
 $matches = array();
 preg_match('!HOSTNAME *= *"([^"]*)".*!', $contents, $matches);
 
-$private_key = $vagrant_directory . "/.vagrant/machines/default/virtualbox/private_key";
-if (!file_exists($private_key)) {
-  $private_key = $vagrant_directory . "/.vagrant/machines/default/vmware_fusion/private_key";
+$private_key = "~/.vagrant.d/insecure_private_key";
+$providers = array('virtualbox', 'vmware_fusion', 'vmware_workstation');
+foreach ($providers as $provider) {
+  $unique_key = $vagrant_directory . "/.vagrant/machines/default/$provider/private_key";
+  if (file_exists($unique_key)) {
+    $private_key = $unique_key;
+    break;
+  }
 }
 
 if (isset($matches[1])) {

--- a/site-aliases/aliases.drushrc.php
+++ b/site-aliases/aliases.drushrc.php
@@ -25,13 +25,18 @@ $contents = file_get_contents($vagrantfile);
 $matches = array();
 preg_match('!HOSTNAME *= *"([^"]*)".*!', $contents, $matches);
 
+$private_key = $vagrant_directory . "/.vagrant/machines/default/virtualbox/private_key";
+if (!file_exists($private_key)) {
+  $private_key = $vagrant_directory . "/.vagrant/machines/default/vmware_fusion/private_key";
+}
+
 if (isset($matches[1])) {
   $fqdn = $matches[1];
   $aliases[$fqdn] = array(
     'uri' => $fqdn,
     'remote-host' => $fqdn,
     'remote-user' => 'vagrant',
-    'ssh-options' => "-i " . $vagrant_directory . "/.vagrant/machines/default/virtualbox/private_key",
+    'ssh-options' => "-i " . $private_key,
     'root' => '/var/www/docroot',
   );
 }


### PR DESCRIPTION
Unfortunately, this requires an update to your ~/.drushrc, and I don't know of a way to easily tell people that. Any ideas other than... tags and release notes?

The issue is that Drush 8 now recurses subdirectories looking for aliases, and we were adding paths all the way up a tree. Even basic `drush help` was locking up, so this is a pretty important fix. I filed a docs issue over at https://github.com/drush-ops/drush/issues/1512

I've tested this isn't broken in Drush 7, but I'd like a confirmation on that.