### PR TITLE
Issue #18: Include Drush 8 and composer in puppet setup.

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -4,6 +4,11 @@ class { 'apt':
   fancy_progress       => false
 }
 
+class { 'composer':
+  command_name => 'composer',
+  target_dir   => '/usr/local/bin'
+}
+
 exec { "apt-get dist-upgrade":
   require => Class['apt'],
   command => "/usr/bin/apt-get -y --auto-remove dist-upgrade",
@@ -54,6 +59,25 @@ vcsrepo { '/opt/drush':
   provider => git,
   source => 'https://github.com/drush-ops/drush.git',
   revision => '6.6.0',
+}
+
+# Drush 8 installation - the repo, the symlink, and running composer install
+vcsrepo { '/opt/drush8':
+  ensure => 'present',
+  provider => git,
+  source => 'https://github.com/drush-ops/drush.git',
+  revision => '8.0.0-beta14',
+}
+
+file { 'drush8':
+  path => '/usr/local/bin/drush8',
+  ensure => 'link',
+  target => '/opt/drush8/drush',
+}
+
+exec { "composer drush8":
+  command => "/usr/local/bin/composer install --working-dir=/opt/drush8",
+  environment => ["HOME=/home/vagrant"], 
 }
 
 # ensure => 'latest' is currently broken, so we use explicit revisions.

--- a/modules/composer/.fixtures.yml
+++ b/modules/composer/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  symlinks:
+    composer: "#{source_dir}"
+  repositories:
+    wget: git://github.com/maestrodev/puppet-wget.git

--- a/modules/composer/.gemfile
+++ b/modules/composer/.gemfile
@@ -1,0 +1,14 @@
+source 'https://rubygems.org'
+
+puppetVersion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : '~> 2.7.0'
+
+gem 'rake'
+gem 'puppet', puppetVersion
+gem 'puppet-lint'
+gem 'puppet-syntax'
+gem 'rspec-puppet'
+gem 'puppetlabs_spec_helper'
+
+if RUBY_VERSION !~ /^1.8/
+  gem 'puppet-blacksmith'
+end

--- a/modules/composer/.gitattributes
+++ b/modules/composer/.gitattributes
@@ -1,0 +1,1 @@
+/spec/fixtures/modules/* export-ignore

--- a/modules/composer/.gitignore
+++ b/modules/composer/.gitignore
@@ -1,0 +1,3 @@
+spec/fixtures/
+pkg/
+.gemfile.lock

--- a/modules/composer/.travis.yml
+++ b/modules/composer/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+
+rvm:
+  - 1.9.3
+
+env:
+  - PUPPET_VERSION="~> 2.7.0"
+  - PUPPET_VERSION="~> 3.1.0"
+  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 3.6.0"
+
+script: "rake test"
+
+gemfile: .gemfile

--- a/modules/composer/LICENSE
+++ b/modules/composer/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2012-2013 William Durand <william.durand1@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/modules/composer/README.md
+++ b/modules/composer/README.md
@@ -1,0 +1,78 @@
+puppet-composer
+===============
+
+[![Build
+Status](https://secure.travis-ci.org/willdurand/puppet-composer.png)](http://travis-ci.org/willdurand/puppet-composer)
+
+This module installs [Composer](http://getcomposer.org/), a dependency manager
+for PHP.
+
+Installation
+------------
+
+Using the Puppet Module Tool, install the
+[`willdurand/composer`](http://forge.puppetlabs.com/willdurand/composer) by
+running the following command:
+
+    puppet module install willdurand/composer
+
+Otherwise, close this repository and make sure to install the proper
+dependencies ([`puppet-wget`](https://github.com/maestrodev/puppet-wget)):
+
+    git clone git://github.com/willdurand/puppet-composer.git modules/composer
+
+**Important:** the right `puppet-wget` module is
+[maestrodev/puppet-wget](https://github.com/maestrodev/puppet-wget). You should
+**not** use any other `puppet-wget` module. Example42's module won't work for
+instance. So, please, run the following command:
+
+    git clone git://github.com/maestrodev/puppet-wget.git modules/wget
+
+
+Usage
+-----
+
+Include the `composer` class:
+
+    include composer
+
+You can specify the command name you want to get, and the target directory (aka
+where to install Composer):
+
+    class { 'composer':
+      command_name => 'composer',
+      target_dir   => '/usr/local/bin'
+    }
+
+You can also auto update composer by using the `auto_update` parameter. This will
+update Composer **only** when you will run Puppet.
+
+    class { 'composer':
+      auto_update => true
+    }
+
+You can specify a particular `user` that will be the owner of the Composer
+executable:
+
+    class { 'composer':
+      user => 'foo',
+    }
+
+
+Running the tests
+-----------------
+
+Install the dependencies using [Bundler](http://gembundler.com):
+
+    BUNDLE_GEMFILE=.gemfile bundle install
+
+Run the following command:
+
+    BUNDLE_GEMFILE=.gemfile bundle exec rake spec
+
+
+License
+-------
+
+puppet-composer is released under the MIT License. See the bundled LICENSE file
+for details.

--- a/modules/composer/Rakefile
+++ b/modules/composer/Rakefile
@@ -1,0 +1,27 @@
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+if RUBY_VERSION !~ /^1.8/
+  require 'puppet_blacksmith/rake_tasks'
+end
+
+PuppetLint.configuration.log_format       = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.fail_on_warnings = false
+PuppetLint.configuration.send("disable_80chars")
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetSyntax.exclude_paths            = exclude_paths
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+]

--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -1,0 +1,76 @@
+# = Class: composer
+#
+# == Parameters:
+#
+# [*target_dir*]
+#   Where to install the composer executable.
+#
+# [*command_name*]
+#   The name of the composer executable.
+#
+# [*user*]
+#   The owner of the composer executable.
+#
+# [*auto_update*]
+#   Whether to run `composer self-update`.
+#
+# == Example:
+#
+#   include composer
+#
+#   class { 'composer':
+#     'target_dir'   => '/usr/local/bin',
+#     'user'         => 'root',
+#     'command_name' => 'composer',
+#     'auto_update'  => true
+#   }
+#
+class composer (
+  $target_dir   = 'UNDEF',
+  $command_name = 'UNDEF',
+  $user         = 'UNDEF',
+  $auto_update  = false
+) {
+
+  include composer::params
+
+  $composer_target_dir = $target_dir ? {
+    'UNDEF' => $::composer::params::target_dir,
+    default => $target_dir
+  }
+
+  $composer_command_name = $command_name ? {
+    'UNDEF' => $::composer::params::command_name,
+    default => $command_name
+  }
+
+  $composer_user = $user ? {
+    'UNDEF' => $::composer::params::user,
+    default => $user
+  }
+
+  wget::fetch { 'composer-install':
+    source      => $::composer::params::phar_location,
+    destination => "${composer_target_dir}/${composer_command_name}",
+    execuser    => $composer_user,
+  }
+
+  exec { 'composer-fix-permissions':
+    command => "chmod a+x ${composer_command_name}",
+    path    => '/usr/bin:/bin:/usr/sbin:/sbin',
+    cwd     => $composer_target_dir,
+    user    => $composer_user,
+    unless  => "test -x ${composer_target_dir}/${composer_command_name}",
+    require => Wget::Fetch['composer-install'],
+  }
+
+  if $auto_update {
+    exec { 'composer-update':
+      command     => "${composer_command_name} self-update",
+      environment => [ "COMPOSER_HOME=${composer_target_dir}" ],
+      path        => "/usr/bin:/bin:/usr/sbin:/sbin:${composer_target_dir}",
+      user        => $composer_user,
+      require     => Exec['composer-fix-permissions'],
+    }
+  }
+}

--- a/modules/composer/manifests/params.pp
+++ b/modules/composer/manifests/params.pp
@@ -1,0 +1,20 @@
+# = Class: composer::params
+#
+# This class defines default parameters used by the main module class composer.
+# Operating Systems differences in names and paths are addressed here.
+#
+# == Variables:
+#
+# Refer to composer class for the variables defined here.
+#
+# == Usage:
+#
+# This class is not intended to be used directly.
+# It may be imported or inherited by other classes.
+#
+class composer::params {
+  $phar_location = 'https://getcomposer.org/composer.phar'
+  $target_dir    = '/usr/local/bin'
+  $command_name  = 'composer'
+  $user          = 'root'
+}

--- a/modules/composer/metadata.json
+++ b/modules/composer/metadata.json
@@ -1,0 +1,48 @@
+{
+  "name": "willdurand-composer",
+  "version": "1.1.1",
+  "author": "William Durand",
+  "license": "MIT",
+  "summary": "This module installs Composer, a dependency manager for PHP.",
+  "source": "https://github.com/willdurand/puppet-composer",
+  "project_page": "https://github.com/willdurand/puppet-composer",
+  "issues_url": "https://github.com/willdurand/puppet-composer/issues",
+  "tags": [
+    "php",
+    "composer"
+  ],
+  "dependencies": [
+    {
+      "name": "maestrodev/wget",
+      "version_requirement": ">=1.2.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ],
+  "types": [
+
+  ],
+  "checksums": {
+    "LICENSE": "8e55fce2ff4cd1331f7c6bc602fe7370",
+    "README.md": "bd086566f845772c926144251c55c20d",
+    "Rakefile": "a1a87b266213b03b33f5e006d4df7925",
+    "manifests/init.pp": "55b84512cbf79fdb3a418d5cf5f422a1",
+    "manifests/params.pp": "8f17a164d1148bc6000f565ec8bbdd04",
+    "spec/classes/composer_spec.rb": "a55830b75a23a61dc55409ab59bc888d",
+    "spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc"
+  }
+}

--- a/modules/composer/spec/classes/composer_spec.rb
+++ b/modules/composer/spec/classes/composer_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe 'composer', :type => :class do
+  let(:title) { 'composer' }
+
+  it { should contain_wget__fetch('composer-install') \
+    .with_source('https://getcomposer.org/composer.phar') \
+    .with_execuser('root') \
+    .with_destination('/usr/local/bin/composer')
+  }
+
+  it { should contain_exec('composer-fix-permissions') \
+    .with_command('chmod a+x composer') \
+    .with_user('root') \
+    .with_cwd('/usr/local/bin')
+  }
+
+  it { should_not contain_exec('composer-update') }
+
+  describe 'with a given target_dir' do
+    let(:params) {{ :target_dir => '/usr/bin' }}
+
+    it { should contain_wget__fetch('composer-install') \
+      .with_source('https://getcomposer.org/composer.phar') \
+      .with_execuser('root') \
+      .with_destination('/usr/bin/composer')
+    }
+
+    it { should contain_exec('composer-fix-permissions') \
+      .with_command('chmod a+x composer') \
+      .with_user('root') \
+      .with_cwd('/usr/bin')
+    }
+
+    it { should_not contain_exec('composer-update') }
+  end
+
+  describe 'with a given command_name' do
+    let(:params) {{ :command_name => 'c' }}
+
+    it { should contain_wget__fetch('composer-install') \
+      .with_source('https://getcomposer.org/composer.phar') \
+      .with_execuser('root') \
+      .with_destination('/usr/local/bin/c')
+    }
+
+    it { should contain_exec('composer-fix-permissions') \
+      .with_command('chmod a+x c') \
+      .with_user('root') \
+      .with_cwd('/usr/local/bin')
+    }
+
+    it { should_not contain_exec('composer-update') }
+  end
+
+  describe 'with auto_update => true' do
+    let(:params) {{ :auto_update => true }}
+
+    it { should contain_wget__fetch('composer-install') \
+      .with_source('https://getcomposer.org/composer.phar') \
+      .with_execuser('root') \
+      .with_destination('/usr/local/bin/composer')
+    }
+
+    it { should contain_exec('composer-fix-permissions') \
+      .with_command('chmod a+x composer') \
+      .with_user('root') \
+      .with_cwd('/usr/local/bin')
+    }
+
+    it { should contain_exec('composer-update') \
+      .with_command('composer self-update') \
+      .with_user('root') \
+      .with_path('/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin')
+    }
+  end
+
+  describe 'with a given user' do
+    let(:params) {{ :user => 'will' }}
+
+    it { should contain_wget__fetch('composer-install') \
+      .with_source('https://getcomposer.org/composer.phar') \
+      .with_execuser('will') \
+      .with_destination('/usr/local/bin/composer')
+    }
+
+    it { should contain_exec('composer-fix-permissions') \
+      .with_command('chmod a+x composer') \
+      .with_user('will') \
+      .with_cwd('/usr/local/bin')
+    }
+
+    it { should_not contain_exec('composer-update') }
+  end
+end

--- a/modules/composer/spec/spec_helper.rb
+++ b/modules/composer/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/wget/.fixtures.yml
+++ b/modules/wget/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    wget: "#{source_dir}"

--- a/modules/wget/.gitignore
+++ b/modules/wget/.gitignore
@@ -1,0 +1,44 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+## MAC OS
+.DS_Store
+
+## TEXTMATE
+*.tmproj
+tmtags
+
+## EMACS
+*~
+\#*
+.\#*
+
+## VIM
+*.swp
+*.swo
+tags
+
+## Bundler
+.bundle
+vendor/
+
+## rbenv / rvm
+.rbenv*
+.rvmrc*
+.ruby-*
+
+## rspec
+spec/fixtures/manifests/
+spec/fixtures/modules/
+
+## Puppet module
+pkg/
+coverage/
+
+## Librarian-puppet
+.tmp/
+.librarian/
+
+
+# Module-specific paths
+Puppetfile.lock

--- a/modules/wget/.nodeset.yml
+++ b/modules/wget/.nodeset.yml
@@ -1,0 +1,10 @@
+default_set: 'centos-64-x64'
+sets:
+  'centos-64-x64':
+    nodes:
+      "main.foo.vm":
+        prefab: 'centos-64-x64'
+  'debian-70rc1-x64':
+    nodes:
+      "main":
+        prefab: 'debian-70rc1-x64'

--- a/modules/wget/.sync.yml
+++ b/modules/wget/.sync.yml
@@ -1,0 +1,11 @@
+Rakefile:
+  strict_variables: false
+.gitignore:
+  paths:
+  - Puppetfile.lock
+.travis.yml:
+  # these versions of puppet just can't run the tests
+  exclude_puppet:
+  - 3.3.0
+  - 3.2.0
+  forge_password: "Bhw0Fli+sIxM+yzjBt6iBEfbja1R7CGnmx2wujIFjtcYxU9TvNuo93ps8cte7ebSGWlJ9/QgKcNnGSgVaO7tkUqusIsWPYZRJ2LsEM9U0bDH9i0ns08l6NaOl0nTT3NPdp/wAhN5pYuMFcZg4r0v+ARzo+3x6NtFH1YYwJqmqR4="

--- a/modules/wget/.travis.yml
+++ b/modules/wget/.travis.yml
@@ -1,0 +1,50 @@
+---
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+before_install:
+  - rm -f Gemfile.lock
+
+rvm:
+  - "2.0.0"
+
+env:
+  - PUPPET_VERSION="~> 3.7.0"
+  - PUPPET_VERSION="~> 3.6.0"
+  - PUPPET_VERSION="~> 3.5.0"
+  - PUPPET_VERSION="~> 3.4.0"
+
+matrix:
+  exclude:
+    # No support for Ruby 2.0 before Puppet 3.2
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 2.7.0"
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.0.0"
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.1.0"
+    # Puppet < 3.5.0 is broken under ruby 2.1 https://tickets.puppetlabs.com/browse/PUP-1243
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 2.7.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.0.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.4.0"
+
+deploy:
+  provider: puppetforge
+  user: maestrodev
+  password:
+    secure: "Bhw0Fli+sIxM+yzjBt6iBEfbja1R7CGnmx2wujIFjtcYxU9TvNuo93ps8cte7ebSGWlJ9/QgKcNnGSgVaO7tkUqusIsWPYZRJ2LsEM9U0bDH9i0ns08l6NaOl0nTT3NPdp/wAhN5pYuMFcZg4r0v+ARzo+3x6NtFH1YYwJqmqR4="
+  on:
+    tags: true
+    # all_branches is required to use tags
+    all_branches: true
+    # Only publish if our main Ruby target builds
+    condition: "$PUPPET_VERSION = '~> 3.6.0'"

--- a/modules/wget/Gemfile
+++ b/modules/wget/Gemfile
@@ -1,0 +1,17 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+source 'https://rubygems.org'
+
+gem 'puppet', ENV['PUPPET_VERSION'] || '>= 2.7', :require => false
+
+gem 'rake', :require => false
+gem 'rspec-puppet', '>= 1.0.0', :require => false
+gem 'puppetlabs_spec_helper', '>= 0.8.0', :require => false
+gem 'puppet-lint', '>= 1.1.0', :require => false
+gem 'simplecov', :require => false
+gem 'puppet-blacksmith', '>= 3.3.0', :require => false
+gem 'librarian-puppet', '>= 2.0.0', :require => false
+gem 'beaker-rspec', '>= 3.0.0', :require => false
+
+# vim:ft=ruby

--- a/modules/wget/Gemfile.lock
+++ b/modules/wget/Gemfile.lock
@@ -1,0 +1,271 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.1)
+    activemodel (4.2.0)
+      activesupport (= 4.2.0)
+      builder (~> 3.1)
+    activesupport (4.2.0)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    addressable (2.3.7)
+    autoparse (0.3.3)
+      addressable (>= 2.3.1)
+      extlib (>= 0.9.15)
+      multi_json (>= 1.0.0)
+    aws-sdk (1.63.0)
+      aws-sdk-v1 (= 1.63.0)
+    aws-sdk-v1 (1.63.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
+    beaker (2.6.0)
+      aws-sdk (~> 1.57)
+      docker-api
+      fission (~> 0.4)
+      fog (~> 1.25)
+      google-api-client (~> 0.8)
+      hocon (~> 0.0.4)
+      inifile (~> 2.0)
+      json (~> 1.8)
+      minitest (~> 5.4)
+      net-scp (~> 1.2)
+      net-ssh (~> 2.9)
+      rbvmomi (~> 1.8)
+      rsync (~> 1.0.9)
+      unf (~> 0.1)
+    beaker-rspec (4.0.0)
+      beaker (~> 2.0)
+      rspec
+      serverspec (~> 1.0)
+      specinfra (~> 1.0)
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    docile (1.1.5)
+    docker-api (1.20.0)
+      excon (>= 0.38.0)
+      json
+    domain_name (0.5.23)
+      unf (>= 0.0.5, < 1.0.0)
+    excon (0.44.4)
+    extlib (0.9.16)
+    facter (1.7.6)
+    faraday (0.9.1)
+      multipart-post (>= 1.2, < 3)
+    fission (0.5.0)
+      CFPropertyList (~> 2.2)
+    fog (1.28.0)
+      fog-atmos
+      fog-aws (~> 0.0)
+      fog-brightbox (~> 0.4)
+      fog-core (~> 1.27, >= 1.27.3)
+      fog-ecloud
+      fog-json
+      fog-profitbricks
+      fog-radosgw (>= 0.0.2)
+      fog-riakcs
+      fog-sakuracloud (>= 0.0.4)
+      fog-serverlove
+      fog-softlayer
+      fog-storm_on_demand
+      fog-terremark
+      fog-vmfusion
+      fog-voxel
+      fog-xml (~> 0.1.1)
+      ipaddress (~> 0.5)
+      nokogiri (~> 1.5, >= 1.5.11)
+    fog-atmos (0.1.0)
+      fog-core
+      fog-xml
+    fog-aws (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-brightbox (0.7.1)
+      fog-core (~> 1.22)
+      fog-json
+      inflecto (~> 0.0.2)
+    fog-core (1.29.0)
+      builder
+      excon (~> 0.38)
+      formatador (~> 0.2)
+      mime-types
+      net-scp (~> 1.1)
+      net-ssh (>= 2.1.3)
+    fog-ecloud (0.0.2)
+      fog-core
+      fog-xml
+    fog-json (1.0.0)
+      multi_json (~> 1.0)
+    fog-profitbricks (0.0.1)
+      fog-core
+      fog-xml
+      nokogiri
+    fog-radosgw (0.0.3)
+      fog-core (>= 1.21.0)
+      fog-json
+      fog-xml (>= 0.0.1)
+    fog-riakcs (0.1.0)
+      fog-core
+      fog-json
+      fog-xml
+    fog-sakuracloud (1.0.0)
+      fog-core
+      fog-json
+    fog-serverlove (0.1.1)
+      fog-core
+      fog-json
+    fog-softlayer (0.4.1)
+      fog-core
+      fog-json
+    fog-storm_on_demand (0.1.0)
+      fog-core
+      fog-json
+    fog-terremark (0.0.4)
+      fog-core
+      fog-xml
+    fog-vmfusion (0.0.1)
+      fission
+      fog-core
+    fog-voxel (0.0.2)
+      fog-core
+      fog-xml
+    fog-xml (0.1.1)
+      fog-core
+      nokogiri (~> 1.5, >= 1.5.11)
+    formatador (0.2.5)
+    google-api-client (0.8.2)
+      activesupport (>= 3.2)
+      addressable (~> 2.3)
+      autoparse (~> 0.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      launchy (~> 2.4)
+      multi_json (~> 1.10)
+      retriable (~> 1.4)
+      signet (~> 0.6)
+    her (0.7.3)
+      activemodel (>= 3.0.0, <= 4.2)
+      activesupport (>= 3.0.0, <= 4.2)
+      faraday (>= 0.8, < 1.0)
+      multi_json (~> 1.7)
+    hiera (1.3.4)
+      json_pure
+    highline (1.7.1)
+    hocon (0.0.7)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    i18n (0.7.0)
+    inflecto (0.0.2)
+    inifile (2.0.2)
+    ipaddress (0.8.0)
+    json (1.8.2)
+    json_pure (1.8.2)
+    jwt (1.4.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    librarian-puppet (2.1.0)
+      librarianp (>= 0.4.0)
+      puppet_forge
+      rsync
+    librarianp (0.6.0)
+      thor (~> 0.15)
+    metaclass (0.0.4)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
+    minitest (5.5.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.11.0)
+    multipart-post (2.0.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.9.2)
+    netrc (0.10.3)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    puppet (3.7.5)
+      facter (> 1.6, < 3)
+      hiera (~> 1.0)
+      json_pure
+    puppet-blacksmith (3.3.1)
+      puppet (>= 2.7.16)
+      rest-client
+    puppet-lint (1.1.0)
+    puppet-syntax (2.0.0)
+      rake
+    puppet_forge (1.0.4)
+      her (~> 0.6)
+    puppetlabs_spec_helper (0.10.0)
+      mocha
+      puppet-lint
+      puppet-syntax
+      rake
+      rspec-puppet
+    rake (10.4.2)
+    rbvmomi (1.8.2)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    retriable (1.4.1)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-its (1.0.1)
+      rspec-core (>= 2.99.0.beta1)
+      rspec-expectations (>= 2.99.0.beta1)
+    rspec-mocks (2.99.3)
+    rspec-puppet (2.0.0)
+      rspec (~> 2.0)
+    rsync (1.0.9)
+    serverspec (1.16.0)
+      highline
+      net-ssh
+      rspec (~> 2.99)
+      rspec-its
+      specinfra (~> 1.27)
+    signet (0.6.0)
+      addressable (~> 2.3)
+      extlib (~> 0.9)
+      faraday (~> 0.9)
+      jwt (~> 1.0)
+      multi_json (~> 1.10)
+    simplecov (0.9.2)
+      docile (~> 1.1.0)
+      multi_json (~> 1.0)
+      simplecov-html (~> 0.9.0)
+    simplecov-html (0.9.0)
+    specinfra (1.27.5)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    trollop (2.1.2)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  beaker-rspec (>= 3.0.0)
+  librarian-puppet (>= 2.0.0)
+  puppet (>= 2.7)
+  puppet-blacksmith (>= 3.3.0)
+  puppet-lint (>= 1.1.0)
+  puppetlabs_spec_helper (>= 0.8.0)
+  rake
+  rspec-puppet (>= 1.0.0)
+  simplecov

--- a/modules/wget/LICENSE
+++ b/modules/wget/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/modules/wget/README.md
+++ b/modules/wget/README.md
@@ -1,0 +1,107 @@
+[![Build Status](https://travis-ci.org/maestrodev/puppet-wget.svg?branch=master)](https://travis-ci.org/maestrodev/puppet-wget)
+[![Puppet Forge](https://img.shields.io/puppetforge/v/maestrodev/wget.svg)](https://forge.puppetlabs.com/maestrodev/wget)
+[![Puppet Forge](https://img.shields.io/puppetforge/f/maestrodev/wget.svg)](https://forge.puppetlabs.com/maestrodev/wget)
+[![Puppet Forge](https://img.shields.io/puppetforge/e/maestrodev/wget.svg)](https://forge.puppetlabs.com/maestrodev/wget)
+
+
+
+A Puppet module to download files with wget, supporting authentication.
+
+# Example
+
+install wget:
+
+```puppet
+    include wget
+```
+
+```puppet
+    wget::fetch { "download Google's index":
+      source      => 'http://www.google.com/index.html',
+      destination => '/tmp/index.html',
+      timeout     => 0,
+      verbose     => false,
+    }
+```
+or alternatively: 
+
+```puppet
+    wget::fetch { 'http://www.google.com/index.html':
+      destination => '/tmp/index.html',
+      timeout     => 0,
+      verbose     => false,
+    }
+```
+This fetches a document which requires authentication:
+
+```puppet
+    wget::fetch { 'Fetch secret PDF':
+      source      => 'https://confidential.example.com/secret.pdf',
+      destination => '/tmp/secret.pdf',
+      user        => 'user',
+      password    => 'p$ssw0rd',
+      timeout     => 0,
+      verbose     => false,
+    }
+```
+
+This caches the downloaded file in an intermediate directory to avoid
+repeatedly downloading it. This uses the timestamping (-N) and prefix (-P)
+wget options to only re-download if the source file has been updated.
+
+```puppet
+    wget::fetch { 'https://tool.com/downloads/tool-1.0.tgz':
+      destination => '/tmp/tool-1.0.tgz',
+      cache_dir   => '/var/cache/wget',
+    }
+```
+
+It's assumed that the cached file will be named after the source's URL
+basename but this assumption can be broken if wget follows some redirects. In
+this case you must inform the correct filename in the cache like this:
+
+```puppet
+    wget::fetch { 'https://tool.com/downloads/tool-latest.tgz':
+      destination => '/tmp/tool-1.0.tgz',
+      cache_dir   => '/var/cache/wget',
+      cache_file  => 'tool-1.1.tgz',
+    }
+```
+
+Checksum can be used in the `source_hash` parameter, with the MD5-sum of the content to be downloaded.
+If content exists, but does not match it is removed before downloading.
+
+
+# Building
+
+Testing is done with rspec, [Beaker-rspec](https://github.com/puppetlabs/beaker-rspec), [Beaker](https://github.com/puppetlabs/beaker))
+
+To test and build the module
+
+    bundle install
+    # run specs
+    rake
+
+    # run Beaker system tests with vagrant vms
+    rake beaker
+    # to use other vm from the list spec/acceptance/nodesets and not destroy the vm after the tests
+    BEAKER_destroy=no BEAKER_set=centos-65-x64-docker bundle exec rake beaker
+
+    # Release the Puppet module to the Forge, doing a clean, build, tag, push, bump_commit and git push
+    rake module:release
+
+# License
+
+Copyright 2011-2013 MaestroDev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/modules/wget/Rakefile
+++ b/modules/wget/Rakefile
@@ -1,0 +1,31 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+require 'rake/clean'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet_blacksmith/rake_tasks'
+
+CLEAN.include('spec/fixtures/manifests/', 'spec/fixtures/modules/', 'doc', 'pkg')
+CLOBBER.include('.tmp', '.librarian')
+
+
+task :librarian_spec_prep do
+  sh "librarian-puppet install --path=spec/fixtures/modules/"
+end
+task :spec_prep => :librarian_spec_prep
+
+Rake::Task[:lint].clear # workaround https://github.com/rodjek/puppet-lint/issues/331
+PuppetLint.configuration.relative = true # https://github.com/rodjek/puppet-lint/pull/334
+PuppetLint::RakeTask.new :lint do |config|
+  config.pattern = 'manifests/**/*.pp'
+  config.disable_checks = ["80chars", "class_inherits_from_params_class"]
+  config.fail_on_warnings = true
+  # config.relative = true
+end
+
+Blacksmith::RakeTask.new do |t|
+  t.build = false # do not build the module nor push it to the Forge, just do the tagging [:clean, :tag, :bump_commit]
+end
+
+task :default => [:clean, :validate, :lint, :spec]

--- a/modules/wget/manifests/authfetch.pp
+++ b/modules/wget/manifests/authfetch.pp
@@ -1,0 +1,35 @@
+################################################################################
+# Definition: wget::authfetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $::http_proxy if necessary. Username must be provided. And the user's
+# password must be stored in the password variable within the .wgetrc file.
+#
+################################################################################
+define wget::authfetch (
+  $destination,
+  $user,
+  $source             = $title,
+  $password           = '',
+  $timeout            = '0',
+  $verbose            = false,
+  $redownload         = false,
+  $nocheckcertificate = false,
+  $execuser           = undef,
+) {
+
+  notice('wget::authfetch is deprecated, use wget::fetch with user/password params')
+
+  wget::fetch { $title:
+    destination        => $destination,
+    source             => $source,
+    timeout            => $timeout,
+    verbose            => $verbose,
+    redownload         => $redownload,
+    nocheckcertificate => $nocheckcertificate,
+    execuser           => $execuser,
+    user               => $user,
+    password           => $password,
+  }
+
+}

--- a/modules/wget/manifests/fetch.pp
+++ b/modules/wget/manifests/fetch.pp
@@ -1,0 +1,163 @@
+################################################################################
+# Definition: wget::fetch
+#
+# This defined type will download files from the internet.  You may define a
+# web proxy using $http_proxy if necessary.
+#
+# == Parameters:
+#  $source_hash:        MD5-sum of the content to be downloaded,
+#                       if content exists, but does not match it is removed
+#                       before downloading
+#
+################################################################################
+define wget::fetch (
+  $destination,
+  $source             = $title,
+  $source_hash        = undef,
+  $timeout            = '0',
+  $verbose            = false,
+  $redownload         = false,
+  $nocheckcertificate = false,
+  $no_cookies         = false,
+  $execuser           = undef,
+  $user               = undef,
+  $password           = undef,
+  $headers            = undef,
+  $cache_dir          = undef,
+  $cache_file         = undef,
+  $flags              = undef,
+  $backup             = true,
+) {
+
+  include wget
+
+  $http_proxy_env = $::http_proxy ? {
+    undef   => [],
+    default => [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ],
+  }
+  $https_proxy_env = $::https_proxy ? {
+    undef   => [],
+    default => [ "HTTPS_PROXY=${::https_proxy}", "https_proxy=${::https_proxy}" ],
+  }
+  $password_env = $user ? {
+    undef   => [],
+    default => [ "WGETRC=${destination}.wgetrc" ],
+  }
+
+  # not using stdlib.concat to avoid extra dependency
+  $environment = split(inline_template('<%= (@http_proxy_env+@https_proxy_env+@password_env).join(\',\') %>'),',')
+
+  $verbose_option = $verbose ? {
+    true  => '--verbose',
+    false => '--no-verbose'
+  }
+
+  if $redownload == true or $cache_dir != undef  {
+    $unless_test = 'test'
+  } else {
+    $unless_test = "test -s '${destination}'"
+  }
+
+  $nocheckcert_option = $nocheckcertificate ? {
+    true  => ' --no-check-certificate',
+    false => ''
+  }
+
+  $no_cookies_option = $no_cookies ? {
+    true  => ' --no-cookies',
+    false => '',
+  }
+
+  $user_option = $user ? {
+    undef   => '',
+    default => " --user=${user}",
+  }
+
+  if $user != undef {
+    $wgetrc_content = $::operatingsystem ? {
+      # This is to work around an issue with macports wget and out of date CA cert bundle.  This requires
+      # installing the curl-ca-bundle package like so:
+      #
+      # sudo port install curl-ca-bundle
+      'Darwin' => "password=${password}\nCA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt\n",
+      default  => "password=${password}",
+    }
+
+    file { "${destination}.wgetrc":
+      owner   => $execuser,
+      mode    => '0600',
+      content => $wgetrc_content,
+      before  => Exec["wget-${name}"],
+    }
+  }
+
+  $output_option = $cache_dir ? {
+    undef   => " --output-document='${destination}'",
+    default => " -N -P '${cache_dir}'",
+  }
+
+  # again, not using stdlib.concat, concatanate array of headers into a single string
+  if $headers != undef {
+    $headers_all = inline_template('<% @headers.each do | header | -%> --header "<%= header -%>"<% end -%>')
+  }
+
+  $header_option = $headers ? {
+    undef   => '',
+    default => $headers_all,
+  }
+
+  $flags_joined = $flags ? {
+    undef => '',
+    default => inline_template(' <%= @flags.join(" ") %>')
+  }
+
+  $exec_user = $cache_dir ? {
+    undef   => $execuser,
+    default => undef,
+  }
+
+  case $source_hash{
+    '', undef: {
+      $command = "wget ${verbose_option}${nocheckcert_option}${no_cookies_option}${header_option}${user_option}${output_option}${flags_joined} '${source}'"
+    }
+    default: {
+      $command = "wget ${verbose_option}${nocheckcert_option}${no_cookies_option}${header_option}${user_option}${output_option}${flags_joined} '${source}' && echo '${source_hash}  ${destination}' | md5sum -c --quiet"
+    }
+  }
+
+
+  exec { "wget-${name}":
+    command     => $command,
+    timeout     => $timeout,
+    unless      => $unless_test,
+    environment => $environment,
+    user        => $exec_user,
+    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin:/usr/sfw/bin',
+    require     => Class['wget'],
+  }
+
+  if $cache_dir != undef {
+    $cache = $cache_file ? {
+      undef   => inline_template('<%= require \'uri\'; File.basename(URI::parse(@source).path) %>'),
+      default => $cache_file,
+    }
+    file { $destination:
+      ensure  => file,
+      source  => "${cache_dir}/${cache}",
+      owner   => $execuser,
+      require => Exec["wget-${name}"],
+      backup  => $backup,
+    }
+  }
+
+  # remove destination if source_hash is invalid
+  if $source_hash != undef {
+    exec { "wget-source_hash-check-${name}":
+      command => "test ! -e '${destination}' || rm ${destination}",
+      path    => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
+      # only remove destination if md5sum does not match $source_hash
+      unless  => "echo '${source_hash}  ${destination}' | md5sum -c --quiet",
+      notify  => Exec["wget-${name}"],
+    }
+  }
+}

--- a/modules/wget/manifests/init.pp
+++ b/modules/wget/manifests/init.pp
@@ -1,0 +1,22 @@
+################################################################################
+# Class: wget
+#
+# This class will install wget - a tool used to download content from the web.
+#
+################################################################################
+class wget (
+  $version = present,
+) {
+
+  if $::kernel == 'Linux' {
+    if ! defined(Package['wget']) {
+      package { 'wget': ensure => $version }
+    }
+  }
+
+  if $::kernel == 'FreeBSD' {
+    if ! defined(Package['ftp/wget']) {
+      package { 'ftp/wget': ensure => $version }
+    }
+  }
+}

--- a/modules/wget/metadata.json
+++ b/modules/wget/metadata.json
@@ -1,0 +1,118 @@
+{
+  "name": "maestrodev-wget",
+  "version": "1.7.0",
+  "source": "https://github.com/maestrodev/puppet-wget.git",
+  "author": "maestrodev",
+  "license": "Apache-2.0",
+  "summary": "Download files with wget",
+  "description": "A module for wget that allows downloading of files, supporting authentication",
+  "project_page": "https://github.com/maestrodev/puppet-wget",
+  "dependencies": [
+
+  ],
+  "requirements": [
+    {
+      "name": "pe",
+      "version_requirement": ">=3.2.0"
+    },
+    {
+      "name": "puppet",
+      "version_requirement": ">=2.7.17"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "4",
+        "5",
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11 SP1"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04"
+      ]
+    },
+    {
+      "operatingsystem": "Solaris",
+      "operatingsystemrelease": [
+        "10",
+        "11"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2003",
+        "Server 2003 R2",
+        "Server 2008",
+        "Server 2008 R2",
+        "Server 2012",
+        "Server 2012 R2",
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "5.3",
+        "6.1",
+        "7.1"
+      ]
+    },
+    {
+      "operatingsystem": "Darwin",
+      "operatingsystemrelease": [
+        "10",
+        "11",
+        "12",
+        "13"
+      ]
+    }
+  ]
+}

--- a/modules/wget/spec/acceptance/nodesets/centos-65-x64-docker.yml
+++ b/modules/wget/spec/acceptance/nodesets/centos-65-x64-docker.yml
@@ -1,0 +1,23 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    image: devopsil/puppet:3.5.1
+    # ip: localhost
+    hypervisor : docker
+    docker_image_commands:
+      - yum -y install tar
+      - useradd vagrant
+      - "sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config"
+      - "sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+    docker_cmd:
+      - 'sh'
+      - '-c'
+      - 'service sshd start; tail -f /dev/null'
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/modules/wget/spec/acceptance/nodesets/centos-65-x64.yml
@@ -1,0 +1,14 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    box : centos-65-x64-virtualbox-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/debian-7-x64-docker.yml
+++ b/modules/wget/spec/acceptance/nodesets/debian-7-x64-docker.yml
@@ -1,0 +1,22 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  debian-7-x64:
+    roles:
+      - master
+    platform: debian-7-amd64
+    image: debian:7
+    # ip: localhost
+    hypervisor : docker
+    docker_image_commands:
+      - useradd vagrant
+      - "sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config"
+      - "sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+    docker_cmd:
+      - 'sh'
+      - '-c'
+      - 'service ssh start; tail -f /dev/null'
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/debian-7-x64.yml
+++ b/modules/wget/spec/acceptance/nodesets/debian-7-x64.yml
@@ -1,0 +1,14 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  debian-7-x64:
+    roles:
+      - master
+    platform: debian-7-amd64
+    box : debian-73-x64-virtualbox-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/debian-73-x64.yml
+++ b/modules/wget/spec/acceptance/nodesets/debian-73-x64.yml
@@ -1,0 +1,14 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  debian-73-x64:
+    roles:
+      - master
+    platform: debian-7-amd64
+    box : debian-73-x64-virtualbox-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/default.yml
+++ b/modules/wget/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,23 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  centos-65-x64:
+    roles:
+      - master
+    platform: el-6-x86_64
+    image: devopsil/puppet:3.5.1
+    # ip: localhost
+    hypervisor : docker
+    docker_image_commands:
+      - yum -y install tar
+      - useradd vagrant
+      - "sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config"
+      - "sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+    docker_cmd:
+      - 'sh'
+      - '-c'
+      - 'service sshd start; tail -f /dev/null'
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/ubuntu-server-1310-x64.yml
+++ b/modules/wget/spec/acceptance/nodesets/ubuntu-server-1310-x64.yml
@@ -1,0 +1,14 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  ubuntu-server-1310-x64:
+    roles:
+      - master
+    platform: ubuntu-13.10-amd64
+    box : ubuntu-server-1310-x64-vbox4210-nocm
+    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-1310-x64-virtualbox-nocm.box
+    hypervisor : vagrant
+CONFIG:
+  log_level   : debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/ubuntu-server-1404-x64-docker.yml
+++ b/modules/wget/spec/acceptance/nodesets/ubuntu-server-1404-x64-docker.yml
@@ -1,0 +1,22 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    image: ubuntu:trusty
+    # ip: localhost
+    hypervisor : docker
+    docker_image_commands:
+      - useradd vagrant
+      - "sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config"
+      - "sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+    docker_cmd:
+      - 'sh'
+      - '-c'
+      - 'service ssh start; tail -f /dev/null'
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/modules/wget/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -1,0 +1,14 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    box : ubuntu-server-1404-x64-cloud
+    box_url : https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box
+    hypervisor : vagrant
+CONFIG:
+  log_level: debug
+  type: git

--- a/modules/wget/spec/acceptance/wget_system_spec.rb
+++ b/modules/wget/spec/acceptance/wget_system_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper_acceptance'
+
+describe 'wget' do
+
+  let(:wget_manifest) { "class { 'wget': }" }
+  let(:manifest) { wget_manifest }
+
+  before do
+    shell "rm -f /tmp/index*"
+  end
+
+  context 'when running as root' do
+    let(:manifest) { super() + %Q(
+        wget::fetch { "download Google's index":
+          source      => 'http://www.google.com/index.html',
+          destination => '/tmp/index.html',
+          timeout     => 0,
+          verbose     => false,
+        }
+      )
+    }
+
+    it 'should be idempotent' do
+      apply_manifest(manifest, :catch_failures => true)
+      apply_manifest(manifest, :catch_changes => true)
+      shell('test -e /tmp/index.html')
+    end
+  end
+
+  context 'when running as user' do
+    before do
+      apply_manifest(wget_manifest, :catch_failures => true)
+    end
+
+    let(:manifest) { %Q(
+      wget::fetch { 'download Google index':
+        source      => 'http://www.google.com/index.html',
+        destination => '/tmp/index-vagrant.html',
+        timeout     => 0,
+        verbose     => false,
+      }
+    ) }
+
+    it "should succeed" do
+      shell("cat << EOF | su - vagrant -c 'puppet apply --verbose --detailed-exitcodes --modulepath=/etc/puppet/modules'\n#{manifest}", :acceptable_exit_codes => [2]) do |r|
+        expect(r.stdout).to match(%r{Wget::Fetch\[download Google index\].*returns: executed successfully})
+      end
+      shell('test -e /tmp/index-vagrant.html')
+    end
+  end
+
+  context 'when running with source_hash' do
+    before do
+      apply_manifest(wget_manifest, :catch_failures => true)
+    end
+
+    # the source_hash for the example.net index page might change over time
+
+    let(:manifest) { %Q(
+      wget::fetch { 'download RFC 2606':
+        source      => 'https://tools.ietf.org/rfc/rfc2606.txt',
+        source_hash => 'c24c7a3118bafb5d7111f9ed5f73264b',
+        destination => '/tmp/rfc-2606.txt',
+        timeout     => 0,
+        verbose     => false,
+      }
+    ) }
+
+    it "should succeed" do
+      shell("cat << EOF | su - vagrant -c 'puppet apply --verbose --detailed-exitcodes --modulepath=/etc/puppet/modules'\n#{manifest}", :acceptable_exit_codes => [2]) do |r|
+        expect(r.stdout).to match(%r{Wget::Fetch\[download RFC 2606\].*returns: executed successfully})
+      end
+      shell('test -e /tmp/rfc-2606.txt')
+    end
+  end
+
+  context 'when running with invalid source_hash' do
+    before do
+      apply_manifest(wget_manifest, :catch_failures => true)
+    end
+
+    let(:manifest) { %Q(
+      wget::fetch { 'download RFC 2606':
+        source      => 'https://tools.ietf.org/rfc/rfc2606.txt',
+        source_hash => '00000000000000000000000000000000',
+        destination => '/tmp/rfc-2606-failed.txt',
+        timeout     => 0,
+        verbose     => false,
+      }
+    ) }
+
+    it "should fail" do
+      shell("cat << EOF | su - vagrant -c 'puppet apply --verbose --detailed-exitcodes --modulepath=/etc/puppet/modules'\n#{manifest}", :acceptable_exit_codes => [6]) do |r|
+        expect(r.stdout).to match(%r{Wget::Fetch\[download RFC 2606\].*returns: md5sum: WARNING: 1 .*computed checksum did NOT match})
+        expect(r.stdout).to match(%r{Wget::Fetch\[download RFC 2606\].*returns: /tmp/rfc-2606-failed.txt: FAILED})
+      end
+      shell('test ! -e /tmp/rfc-2606-failed')
+    end
+  end
+end

--- a/modules/wget/spec/classes/init_spec.rb
+++ b/modules/wget/spec/classes/init_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'wget' do
+
+  let(:facts) { {
+    :operatingsystem => 'CentOS',
+    :kernel => 'Linux'
+  } }
+
+  context 'no version specified', :compile do
+    it { should contain_package('wget').with_ensure('present') }
+  end
+
+  context 'version is 1.2.3', :compile do
+    let(:params) { {:version => '1.2.3'} }
+
+    it { should contain_package('wget').with_ensure('1.2.3') }
+  end
+
+  context 'running on OS X', :compile do
+    let(:facts) { {
+      :operatingsystem => 'Darwin',
+      :kernel => 'Darwin'
+    } }
+
+    it { should_not contain_package('wget') }
+  end
+
+  context 'running on FreeBSD', :compile do
+    let(:facts) { {
+      :operatingsystem => 'FreeBSD',
+      :kernel => 'FreeBSD'
+    } }
+
+    it { should contain_package('ftp/wget') }
+  end
+end

--- a/modules/wget/spec/defines/authfetch_spec.rb
+++ b/modules/wget/spec/defines/authfetch_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'wget::authfetch' do
+  let(:title) { 'authtest' }
+  let(:params) {{
+    :source      => 'http://localhost/source',
+    :destination => destination,
+    :user        => 'myuser',
+    :password    => 'mypassword',
+  }}
+
+  let(:destination) { "/tmp/dest" }
+
+  context "with default params", :compile do
+    it { should contain_exec('wget-authtest').with({
+      'command'     => "wget --no-verbose --user=myuser --output-document='#{destination}' 'http://localhost/source'",
+      'environment' => "WGETRC=#{destination}.wgetrc"
+      })
+    }
+    it { should contain_file("#{destination}.wgetrc").with_content('password=mypassword') }
+  end
+
+  context "with user", :compile do
+    let(:params) { super().merge({
+      :execuser => 'testuser',
+    })}
+
+    it { should contain_exec('wget-authtest').with({
+      'command' => "wget --no-verbose --user=myuser --output-document='#{destination}' 'http://localhost/source'",
+      'user'    => 'testuser'
+    }) }
+  end
+end

--- a/modules/wget/spec/defines/fetch_spec.rb
+++ b/modules/wget/spec/defines/fetch_spec.rb
@@ -1,0 +1,159 @@
+require 'spec_helper'
+
+describe 'wget::fetch' do
+  let(:title) { 'test' }
+  let(:facts) {{}}
+
+  let(:params) {{
+    :source      => 'http://localhost/source',
+    :destination => destination,
+  }}
+
+  let(:destination) { "/tmp/dest" }
+
+  context "with default params", :compile do
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document='#{destination}' 'http://localhost/source'",
+      'environment' => []
+    }) }
+  end
+
+  context "with user", :compile do
+    let(:params) { super().merge({
+      :execuser => 'testuser',
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document='#{destination}' 'http://localhost/source'",
+      'user' => 'testuser',
+      'environment' => []
+    }) }
+  end
+
+  context "with authentication", :compile do
+    let(:params) { super().merge({
+      :user => 'myuser',
+      :password => 'mypassword'
+    })}
+
+    context "with default params" do
+      it { should contain_exec('wget-test').with({
+        'command'     => "wget --no-verbose --user=myuser --output-document='#{destination}' 'http://localhost/source'",
+        'environment' => "WGETRC=#{destination}.wgetrc"
+        })
+      }
+      it { should contain_file("#{destination}.wgetrc").with_content('password=mypassword') }
+    end
+
+    context "with user", :compile do
+      let(:params) { super().merge({
+        :execuser => 'testuser',
+      })}
+
+      it { should contain_exec('wget-test').with({
+        'command' => "wget --no-verbose --user=myuser --output-document='#{destination}' 'http://localhost/source'",
+        'user' => 'testuser',
+        'environment' => "WGETRC=#{destination}.wgetrc"
+      }) }
+    end
+
+    context "using proxy", :compile do
+      let(:facts) { super().merge({
+        :http_proxy => 'http://proxy:1000',
+        :https_proxy => 'http://proxy:1000'
+      }) }
+      it { should contain_exec('wget-test').with({
+        'command'     => "wget --no-verbose --user=myuser --output-document='#{destination}' 'http://localhost/source'",
+        'environment' => ["HTTP_PROXY=http://proxy:1000", "http_proxy=http://proxy:1000", "HTTPS_PROXY=http://proxy:1000", "https_proxy=http://proxy:1000", "WGETRC=#{destination}.wgetrc"]
+        })
+      }
+      it { should contain_file("#{destination}.wgetrc").with_content('password=mypassword') }
+    end
+  end
+
+  context "with cache", :compile do
+    let(:params) { super().merge({
+      :cache_dir => '/tmp/cache',
+      :execuser  => 'testuser',
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose -N -P '/tmp/cache' 'http://localhost/source'",
+      'environment' => []
+    }) }
+
+    it { should contain_file("#{destination}").with({
+      'ensure'  => "file",
+      'source'  => "/tmp/cache/source",
+      'owner'   => "testuser",
+    }) }
+  end
+
+  context "with cache file", :compile do
+    let(:params) { super().merge({
+      :cache_dir  => '/tmp/cache',
+      :cache_file => 'newsource',
+      :execuser   => 'testuser',
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose -N -P '/tmp/cache' 'http://localhost/source'",
+      'environment' => []
+    }) }
+
+    it { should contain_file("#{destination}").with({
+      'ensure'  => "file",
+      'source'  => "/tmp/cache/newsource",
+      'owner'   => "testuser",
+    }) }
+  end
+
+  context "with multiple headers", :compile do
+    let(:params) { super().merge({
+      :headers => ['header1', 'header2'],
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --header \"header1\" --header \"header2\" --output-document='#{destination}' 'http://localhost/source'",
+      'environment' => []
+    }) }
+  end
+
+  context "with no-cookies", :compile do
+    let(:params) { super().merge({
+      :no_cookies => true,
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --no-cookies --output-document='#{destination}' 'http://localhost/source'",
+      'environment' => []
+    }) }
+  end
+
+  context "with flags", :compile do
+    let(:params) { super().merge({
+      :flags => ['--flag1', '--flag2'],
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document='#{destination}' --flag1 --flag2 'http://localhost/source'",
+      'environment' => []
+    }) }
+  end
+
+  context "with source_hash", :compile do
+    let(:params) { super().merge({
+      :source_hash => "d41d8cd98f00b204e9800998ecf8427e",
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document='#{destination}' 'http://localhost/source' && echo 'd41d8cd98f00b204e9800998ecf8427e  #{destination}' | md5sum -c --quiet",
+      'environment' => []
+    }) }
+
+    it { should contain_exec('wget-source_hash-check-test').with({
+      'command' => "test ! -e '#{destination}' || rm #{destination}",
+      'unless'  => "echo 'd41d8cd98f00b204e9800998ecf8427e  #{destination}' | md5sum -c --quiet",
+    })}
+  end
+end

--- a/modules/wget/spec/fixtures/hiera.yaml
+++ b/modules/wget/spec/fixtures/hiera.yaml
@@ -1,0 +1,11 @@
+---
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+:backends:
+  - rspec
+  - yaml
+:yaml:
+  :datadir: './spec/fixtures/hieradata'
+:hierarchy:
+  - '%{::clientcert}'
+  - 'default'

--- a/modules/wget/spec/spec_helper.rb
+++ b/modules/wget/spec/spec_helper.rb
@@ -1,0 +1,34 @@
+# This file is managed centrally by modulesync
+#   https://github.com/maestrodev/puppet-modulesync
+
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  c.treat_symbols_as_metadata_keys_with_true_values = true
+  c.mock_with :rspec
+  c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
+
+  c.before(:each) do
+    Puppet::Util::Log.level = :warning
+    Puppet::Util::Log.newdestination(:console)
+  end
+
+  c.default_facts = {
+    :operatingsystem => 'CentOS',
+    :operatingsystemrelease => '6.6',
+    :kernel => 'Linux',
+    :osfamily => 'RedHat',
+    :architecture => 'x86_64',
+    :clientcert => 'puppet.acme.com'
+  }.merge({})
+
+  c.before do
+    # avoid "Only root can execute commands as other users"
+    Puppet.features.stubs(:root? => true)
+  end
+end
+
+shared_examples :compile, :compile => true do
+  it { should compile.with_all_deps }
+end
+

--- a/modules/wget/spec/spec_helper_acceptance.rb
+++ b/modules/wget/spec/spec_helper_acceptance.rb
@@ -1,0 +1,50 @@
+require 'puppet'
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+
+# overriding puppet installation for the RedHat family distros due to
+# puppet breakage >= 3.5
+def install_puppet(host)
+  host['platform'] =~ /(fedora|el)-(\d+)/
+  if host['platform'] =~ /(fedora|el)-(\d+)/
+    safeversion = '3.4.2'
+    platform = $1
+    relver = $2
+    on host, "rpm -ivh http://yum.puppetlabs.com/puppetlabs-release-#{platform}-#{relver}.noarch.rpm"
+    on host, "yum install -y puppet-#{safeversion}"
+  else
+    super()
+  end
+end
+
+RSpec.configure do |c|
+
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  c.before(:each) do
+    Puppet::Util::Log.level = :warning
+    Puppet::Util::Log.newdestination(:console)
+  end
+
+  c.before :suite do
+    hosts.each do |host|
+      unless (ENV['RS_PROVISION'] == 'no' || ENV['BEAKER_provision'] == 'no')
+        begin
+          on host, 'puppet --version'
+        rescue
+          if host.is_pe?
+            install_pe
+          else
+            install_puppet(host)
+          end
+        end
+      end
+
+      # Install module and dependencies
+      puppet_module_install(:source => proj_root, :module_name => File.basename(proj_root).gsub(/^puppet-/,''))
+
+    end
+  end
+
+end


### PR DESCRIPTION
This is an effort to resolve #18, so this vagrant setup can easier support Drupal 8 development.

I downloads a release of Drush 8, installs composer, runs "composer install" in the proper drush directory, and sets up a "drush8" alias to use.