### PR TITLE
[#22] Only set paravirtprovider on Virtualbox 5+

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -140,7 +140,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
        # VirtualBox 5 supports paravirtualization, and defaults this setting to
        # 'legacy' which isn't enabling KVM.
-       vb.customize ['modifyvm', :id, '--paravirtprovider', 'default']
+       begin
+         if VagrantPlugins::ProviderVirtualBox::Driver::Meta.new.version >= "5.0.0"
+           vb.customize ['modifyvm', :id, '--paravirtprovider', 'default']
+         end
+         rescue Vagrant::Errors::VirtualBoxNotDetected
+       end
   end
 
   config.vm.provider "vmware_fusion" do |v|


### PR DESCRIPTION
@makangus @jazzdrive3 mind checking this for me, as I don't have version 4 installed anywhere?

If you're on an old setup from before I moved the basebox to Atlas this might not work at all for you.