### PR TITLE
Support VirtualBox linked clones

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,6 +126,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # Don't boot with headless mode
       # vb.gui = true
 
+      # Use linked clones in Virtualbox. This is currently opt-in and not
+      # supported in vanilla VMWare Fusion, so we only set this for VirtualBox.
+      vb.linked_clone = true
+
       # RESOURCE SETTINGS
       vb.customize ["modifyvm", :id, "--memory", MEMORY]
 


### PR DESCRIPTION
See https://hashicorp.com/blog/vagrant-1-8.html and https://github.com/mitchellh/vagrant/issues/6737#issuecomment-167656880

Existing machines would need to be recreated to take advantage of this, but as soon as you have more than one machine you can start saving gigabytes of disk space (yay!)