### PR TITLE
Add some more docs about CLI debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,18 @@ debugging session. For PHPStorm, the [bookmarklet generator](https://www.jetbrai
 works well.
 
 For CLI and Drush debugging, use the included `php-debug` script to start a
-shell with debugging enabled.
+shell with debugging enabled. First grab the host name or IP of your local
+machine (for example run `hostname -f`).  Next SSH into your Vagrant box and
+run:
+
+```
+$ php-debug <hostname of local machine>
+```
+
+Next ensure that your debugging client on your local machine is listening for
+connections (eg. in PHPStorm: Run > Start Listening for PHP Debug Connections).
+Finally run your CLI and Drush commands from the Vagrant box and xdebug should
+connect to PHPStorm and allow you to start stepping through.
 
 PHP Profiling with XHGui
 ------------------------

--- a/php-debug
+++ b/php-debug
@@ -6,7 +6,7 @@ REMOTE=$1
 if [[ -z "$REMOTE" ]]
 then
   echo "A remote host to connect to for debugging must be provided."
-  echo "Example: drush-debug.sh example.lan"
+  echo "Example: php-debug example.lan"
   exit 1
 fi
 


### PR DESCRIPTION
Add some more documentation for remote debugging CLI and Drush commands with xdebug.  Fix a reference to the old script name in the php-debug script.