### PR TITLE
Make /var/www owned by www-data for vboxsf mounts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -107,7 +107,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   case SYNC_TYPE
     when "vbox"
-      config.vm.synced_folder SYNC_DIRECTORY, "/var/www"
+      config.vm.synced_folder SYNC_DIRECTORY, "/var/www", owner: "www-data", group: "www-data"
 
     when "nfs"
       config.vm.synced_folder SYNC_DIRECTORY, "/var/www", type: "nfs"


### PR DESCRIPTION
This isn't a best practice for production environments, but for locals where the app often needs to write to the shared directory I think this makes sense. And, it fixes an issue where the vboxsf driver lets files get created that it can't read.