### PR TITLE
Full PHP 7.1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Updating baseboxes
 1. Set `USE_INSECURE_KEY` to true in the `Vagrantfile`.
 1. Set `PROVISIONING` to true in the `Vagrantfile`.
 1. Run `vagrant up`.
+1. Run `vagrant provision` until it passes.
 1. Run `vagrant reload` to verify any upgraded kernels.
 1. Update the Virtualbox guest additions.
 1. Push any changes in `/etc/` to https://github.com/Lullabot/trusty32-lamp-etc.

--- a/README.md
+++ b/README.md
@@ -402,6 +402,9 @@ Updating baseboxes
 1. Use `apt-get purge` to remove any old linux-image and linux-header packages to
    save disk space.
 1. Run `vagrant reload` just to make sure grub is still working.
+1. Run
+   `vagrant snapshot push && vagrant ssh --command='sudo /vagrant/test.sh' && vagrant snapshot pop`
+   to ensure that the web server, xdebug, and xhgui are working.
 1. Run `vagrant ssh -c /vagrant/zero-free-space` to zero free space on the
    disk.
 1. Halt the box.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,7 @@ HOSTNAME = "trusty-lamp.local"
 # This is disabled by default as it can break on some captive Wifi networks
 # like those in airprots or hotels. Turn this back off if your VM doesn't boot
 # in a new network environment!
-PUBLIC_NETWORK = FALSE
+PUBLIC_NETWORK = false
 
 # Set a static IP for this box in addition to the DHCP IP.
 # STATIC_IP = "192.168.100.100"
@@ -62,7 +62,7 @@ USE_INSECURE_KEY = false
 # Provision this VM on boot using Puppet. This is used when updating the base
 # boxes, and isn't required for day-to-day use. When turning on, a box will
 # need to be rebooted so Vagrant can mount the proper directories.
-PROVISION = false
+PROVISION = true
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
@@ -156,7 +156,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider "vmware_desktop" do |v|
       v.vmx["memsize"] = MEMORY
       v.vmx["numvcpus"] = CPUS
-      v.vmx["tools.synctime"] = TRUE
+      v.vmx["tools.synctime"] = true
   end
 
   # All Vagrant configuration is done here. The most common configuration

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -62,7 +62,7 @@ USE_INSECURE_KEY = false
 # Provision this VM on boot using Puppet. This is used when updating the base
 # boxes, and isn't required for day-to-day use. When turning on, a box will
 # need to be rebooted so Vagrant can mount the proper directories.
-PROVISION = true
+PROVISION = false
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -236,6 +236,12 @@ package { 'php5.6-bcmath':
 package { 'php7.0-bcmath':
   ensure => 'latest',
 }
+package { 'php7.1-bcmath':
+  ensure => 'latest',
+}
+package { 'php7.2-bcmath':
+  ensure => 'latest',
+}
 package { 'php-cli':
   ensure => 'latest',
 }
@@ -287,7 +293,20 @@ package { 'php5.6-mbstring':
 package { 'php7.0-mbstring':
   ensure => 'latest',
 }
+package { 'php7.1-mbstring':
+  ensure => 'latest',
+}
+package { 'php7.2-mbstring':
+  ensure => 'latest',
+}
 package { 'php-mcrypt':
+  ensure => 'latest',
+}
+# mcrypt has been removed as of PHP 7.2.
+package { 'php7.1-mcrypt':
+  ensure => 'latest',
+}
+package { 'php7.0-mcrypt':
   ensure => 'latest',
 }
 package { 'php5.6-mcrypt':

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -188,6 +188,12 @@ package { 'htop':
 package { 'lbzip2':
   ensure => 'latest',
 }
+package { 'zip':
+  ensure => 'latest',
+}
+package { 'unzip':
+  ensure => 'latest',
+}
 package { 'lvm2':
   ensure => 'latest',
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -281,7 +281,7 @@ package { 'php-memcached':
 package { 'php-msgpack':
   ensure => 'latest',
 }
-package { 'php-mongo':
+package { 'php-mongodb':
   ensure => 'latest',
 }
 package { 'php-mysql':

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -72,7 +72,7 @@ vcsrepo { '/opt/drush':
   ensure => 'present',
   provider => git,
   source => 'https://github.com/drush-ops/drush.git',
-  revision => '8.1.3',
+  revision => '8.1.15',
 }
 
 exec { "composer self-update":

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -140,6 +140,15 @@ package { 'apache2':
 package { 'libapache2-mod-php':
   ensure => 'latest',
 }
+package { 'libapache2-mod-php7.2':
+  ensure => 'latest',
+}
+package { 'libapache2-mod-php7.1':
+  ensure => 'latest',
+}
+package { 'libapache2-mod-php7.0':
+  ensure => 'latest',
+}
 package { 'libapache2-mod-php5.6':
   ensure => 'latest',
 }
@@ -245,7 +254,19 @@ package { 'php7.0-curl':
 package { 'php7.1-curl':
   ensure => 'latest',
 }
+package { 'php7.2-curl':
+  ensure => 'latest',
+}
 package { 'php-gd':
+  ensure => 'latest',
+}
+package { 'php7.2-gd':
+  ensure => 'latest',
+}
+package { 'php7.1-gd':
+  ensure => 'latest',
+}
+package { 'php7.0-gd':
   ensure => 'latest',
 }
 package { 'php5.6-gd':
@@ -293,6 +314,12 @@ package { 'php5.6-mysql':
 package { 'php7.0-mysql':
   ensure => 'latest',
 }
+package { 'php7.1-mysql':
+  ensure => 'latest',
+}
+package { 'php7.2-mysql':
+  ensure => 'latest',
+}
 package { 'php-oauth':
   ensure => 'latest',
 }
@@ -314,6 +341,15 @@ package { 'php-xhprof':
 package { 'php-xml':
   ensure => 'latest',
 }
+package { 'php7.2-xml':
+  ensure => 'latest',
+}
+package { 'php7.1-xml':
+  ensure => 'latest',
+}
+package { 'php7.0-xml':
+  ensure => 'latest',
+}
 package { 'php5.6-xml':
   ensure => 'latest',
 }
@@ -327,6 +363,15 @@ package { 'php5.6-xmlrpc':
   ensure => 'latest',
 }
 package { 'php-zip':
+  ensure => 'latest',
+}
+package{ 'php7.2-zip':
+  ensure => 'latest',
+}
+package{ 'php7.1-zip':
+  ensure => 'latest',
+}
+package{ 'php7.0-zip':
   ensure => 'latest',
 }
 package{ 'php5.6-zip':

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -ex
+
+# This script expects to be run as root. It can be run with:
+#   $ vagrant ssh --command "sudo /vagrant/test.sh"
+test() {
+  # Download Drupal 8 and install it.
+  cd /var/www
+  rm -rf /var/www/docroot
+
+  drush dl drupal --destination=/var/www --drupal-project-rename=docroot -y
+  sudo chown -Rv www-data:vagrant /var/www/docroot/sites/default
+  cd /var/www/docroot
+
+  # Test the installer loads.
+  wget -q -O - http://localhost/ | grep 'Choose language'
+
+  # Test installing Drupal.
+  sudo -u www-data drush si --db-url=mysql://root@localhost/drupal8 -y
+
+  # curl the Drupal 8 home page.
+  wget -q -O - http://localhost/ | grep "Site-Install"
+
+  # Test debugging.
+  echo '<?php print_r(get_loaded_extensions());' > /var/www/docroot/extensions.php
+  wget -q -O - http://localhost/extensions.php | grep xdebug
+
+  # Test xhgui.
+  wget -q -O - http://localhost/extensions.php | grep tideways
+  mongo xhprof --eval "db.dropDatabase();"
+  wget -q -O - http://localhost/?xhgui=on > /dev/null
+  wget -q -O - http://localhost/xhgui | grep '/?xhgui=on'
+}
+
+# Test each php version.
+VERSIONS="php5.6 php7.0 php7.1"
+for VERSION in  $VERSIONS
+do
+  echo "Testing $VERSION..."
+  a2dismod $VERSIONS
+  a2enmod $VERSION
+  service apache2 restart
+  update-alternatives --set php /usr/bin/$VERSION
+  test
+done
+
+echo 'All tests passed!'

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,6 @@ test() {
   rm -rf /var/www/docroot
 
   drush dl drupal --destination=/var/www --drupal-project-rename=docroot -y
-  sudo chown -Rv www-data:vagrant /var/www/docroot/sites/default
   cd /var/www/docroot
 
   # Test the installer loads.

--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,7 @@ test() {
   rm -rf /var/www/docroot
 
   drush dl drupal --destination=/var/www --drupal-project-rename=docroot -y
+  sudo chown -Rv www-data:vagrant /var/www/docroot/sites/default
   cd /var/www/docroot
 
   # Test the installer loads.

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -eE
 
 # This script expects to be run as root. It can be run with:
 #   $ vagrant ssh --command "sudo /vagrant/test.sh"
@@ -29,6 +31,12 @@ test() {
   wget -q -O - http://localhost/?xhgui=on > /dev/null
   wget -q -O - http://localhost/xhgui | grep '/?xhgui=on'
 }
+
+err_report() {
+  echo "Error on line $(caller)" >&2
+}
+
+trap err_report ERR
 
 # Test each php version.
 VERSIONS="php5.6 php7.0 php7.1"


### PR DESCRIPTION
The real guts of this PR add a script that does some basic tests to ensure each version of PHP is functional. Unfortunately, PHP 7.2 isn't supported by Drupal yet, and xdebug doesn't have a stable release either, so that's omitted for now.

I would have liked to wire this up to a CI tool, but that requires running Virtualbox, and I have yet to find one that supports the required kernel extensions.

I've built this PR against the 32-bit box and will be uploading it and the 64-bit box soon.